### PR TITLE
Branch undo command

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -153,19 +153,27 @@ This section describes some noteworthy details on how certain features are imple
 === [Proposed] Undo/Redo feature
 ==== Proposed Implementation
 
-The undo/redo mechanism is facilitated by `VersionedAddressBook`.
-It extends `AddressBook` with an undo/redo history, stored internally as an `addressBookStateList` and `currentStatePointer`.
+The undo/redo mechanism is facilitated by `UndoableHistory`.
+It contains an undo/redo history, stored internally as an `addressBookStateList` and a `currentStateIndex`.
+`UndoableHistory` also contains a `mainAddressBook`, which is the `AddressBook` that the GUI is in sync with.
+
+It is important that the `Model` works only with the `mainAddressBook` (and not duplicates) for this reason.
+This `mainAddressBook` is updated every time an undo or redo occurs.
+
 Additionally, it implements the following operations:
 
-* `VersionedAddressBook#commit()` -- Saves the current address book state in its history.
-* `VersionedAddressBook#undo()` -- Restores the previous address book state from its history.
-* `VersionedAddressBook#redo()` -- Restores a previously undone address book state from its history.
+* `UndoableHistory#commit()` -- Creates a deep-copy of the `mainAddressBook` state and saves that copy to its history.
+* `UndoableHistory#undo()` -- Retrieve `mainAddressBook` 's previous state data from its duplicate and restore `mainAddressBook`
+* `UndoableHistory#redo()` -- Retrieve `mainAddressBook` 's future state data from its duplicate and restore `mainAddressBook`
+* `UndoableHistory#clearFutureHistory()` -- Delete all duplicates of `mainAddressBook` that occur after the index given by the `currentStateIndex`
+in `addressBookStateList`
 
-These operations are exposed in the `Model` interface as `Model#commitAddressBook()`, `Model#undoAddressBook()` and `Model#redoAddressBook()` respectively.
+These operations are exposed in the `Model` interface as `Model#commitAddressBook()`, `Model#undoFromHistory()` and `Model#redoFromHistory()`, and `Model#clearFutureHistory()` respectively.
 
 Given below is an example usage scenario and how the undo/redo mechanism behaves at each step.
 
-Step 1. The user launches the application for the first time. The `VersionedAddressBook` will be initialized with the initial address book state, and the `currentStatePointer` pointing to that single address book state.
+Step 1. The user launches the application for the first time. The `UndoableHistory` will be initialized with the initial `mainAddressBook`. A duplicate of `mainAddressBook` will be added to `addressBookStateList`
+and the `currentStateIndex` will point to that single address book state in the list.
 
 image::UndoRedoState0.png[]
 
@@ -185,7 +193,7 @@ Step 4. The user now decides that adding the person was a mistake, and decides t
 image::UndoRedoState3.png[]
 
 [NOTE]
-If the `currentStatePointer` is at index 0, pointing to the initial address book state, then there are no previous address book states to restore. The `undo` command uses `Model#canUndoAddressBook()` to check if this is the case. If so, it will return an error to the user rather than attempting to perform the undo.
+If the `currentStateIndex` is 0, pointing to the initial address book state, then there are no previous address book states to restore. The `undo` command uses `Model#canUndoAddressBook()` to check if this is the case. If so, it will return an error to the user rather than attempting to perform the undo.
 
 The following sequence diagram shows how the undo operation works:
 
@@ -193,16 +201,17 @@ image::UndoSequenceDiagram.png[]
 
 NOTE: The lifeline for `UndoCommand` should end at the destroy marker (X) but due to a limitation of PlantUML, the lifeline reaches the end of diagram.
 
-The `redo` command does the opposite -- it calls `Model#redoAddressBook()`, which shifts the `currentStatePointer` once to the right, pointing to the previously undone state, and restores the address book to that state.
+The `redo` command does the opposite -- it calls `Model#redoFromHistory()`, which shifts the `currentStateIndex` once to the right, pointing to the previously undone state, and restores the address book to that state.
 
 [NOTE]
-If the `currentStatePointer` is at index `addressBookStateList.size() - 1`, pointing to the latest address book state, then there are no undone address book states to restore. The `redo` command uses `Model#canRedoAddressBook()` to check if this is the case. If so, it will return an error to the user rather than attempting to perform the redo.
+If the `currentStateIndex` is `addressBookStateList.size() - 1`, pointing to the latest address book state, then there are no undone address book states to restore. The `redo` command uses `Model#canRedoAddressBook()` to check if this is the case. If so, it will return an error to the user rather than attempting to perform the redo.
 
 Step 5. The user then decides to execute the command `list`. Commands that do not modify the address book, such as `list`, will usually not call `Model#commitAddressBook()`, `Model#undoAddressBook()` or `Model#redoAddressBook()`. Thus, the `addressBookStateList` remains unchanged.
 
 image::UndoRedoState4.png[]
 
-Step 6. The user executes `clear`, which calls `Model#commitAddressBook()`. Since the `currentStatePointer` is not pointing at the end of the `addressBookStateList`, all address book states after the `currentStatePointer` will be purged. We designed it this way because it no longer makes sense to redo the `add n/David ...` command. This is the behavior that most modern desktop applications follow.
+Step 6. The user executes `clear`, which calls `Model#clearFutureHistory` and then Model#commitAddressBook()`.
+Since the `currentStateIndex` is not pointing at the end of the `addressBookStateList`, all address book states after the `currentStateIndex` will be purged. We designed it this way because it no longer makes sense to redo the `add n/David ...` command. This is the behavior that most modern desktop applications follow.
 
 image::UndoRedoState5.png[]
 

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -292,7 +292,7 @@ Format: +
 
 === Undo Redo
 
-==== Undo **`[coming in v2.0]`**
+==== Undo
 
 Undoes the previous command. +
 Commands can be undone up to the starting up of the program

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -9,5 +9,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_NOTHING_TO_UNDO = "There is nothing to undo";
 
 }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -54,6 +54,7 @@ public class AddCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
+        model.clearFutureHistory();
         model.addPerson(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -17,6 +17,7 @@ public class ClearCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+        model.clearFutureHistory();
         model.setAddressBook(new AddressBook());
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -40,6 +40,7 @@ public class DeleteCommand extends Command {
         }
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
+        model.clearFutureHistory();
         model.deletePerson(personToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
     }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -81,6 +81,7 @@ public class EditCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
+        model.clearFutureHistory();
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -1,0 +1,32 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+
+import seedu.address.model.Model;
+
+/**
+ * Undoes the previous command.
+ * Commands can be undone up to the starting up of the program.
+ */
+public class UndoCommand extends Command {
+
+    public static final String COMMAND_WORD = "undo";
+
+    public static final String MESSAGE_SUCCESS = "The previous command has been undone";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (!undoableHistory.isUndoable()) {
+            throw new CommandException(MESSAGE_NOTHING_TO_UNDO);
+        }
+
+        undoableHistory.undo();
+
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -2,6 +2,8 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import seedu.address.commons.core.Messages;
+
 import seedu.address.logic.commands.exceptions.CommandException;
 
 import seedu.address.model.Model;
@@ -20,11 +22,11 @@ public class UndoCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (!undoableHistory.isUndoable()) {
-            throw new CommandException(MESSAGE_NOTHING_TO_UNDO);
+        if (!model.canUndoHistory()) {
+            throw new CommandException(Messages.MESSAGE_NOTHING_TO_UNDO);
         }
 
-        undoableHistory.undo();
+        model.undoFromHistory();
 
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/seedu/address/logic/commands/UndoableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoableCommand.java
@@ -1,4 +1,0 @@
-package seedu.address.logic.commands;
-
-public abstract class UndoableCommand extends Command {
-}

--- a/src/main/java/seedu/address/logic/commands/UndoableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoableCommand.java
@@ -1,0 +1,4 @@
+package seedu.address.logic.commands;
+
+public abstract class UndoableCommand extends Command {
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -6,15 +6,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.ExitCommand;
-import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.*;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -61,6 +53,9 @@ public class AddressBookParser {
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
+
+        case UndoCommand.COMMAND_WORD:
+            return new UndoCommand();
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -6,7 +6,17 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.address.logic.commands.*;
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.UndoCommand;
+
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -37,6 +37,15 @@ public class AddressBook implements ReadOnlyAddressBook {
         resetData(toBeCopied);
     }
 
+    /**
+     * Returns a deep-copy of an AddressBook.
+     *
+     * @param oldAddressBook the AddressBook to deep-copy.
+     */
+    public AddressBook(AddressBook oldAddressBook) {
+        this.persons.setPersons(new UniquePersonList(oldAddressBook.persons));
+    }
+
     //// list overwrite operations
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -106,4 +106,10 @@ public interface Model {
      * @return boolean
      */
     boolean canUndoHistory();
+
+    /**
+     * Clears all future address book states in UndoableHistory beyond the current state.
+     */
+    void clearFutureHistory();
+
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -88,15 +88,22 @@ public interface Model {
     /**
      * Saves the current AddressBook state to the UndoableHistory.
      */
-    void commitAddressBook();
+    void commitToHistory();
 
     /**
      * Restores the previous address book state from UndoableHistory.
      */
-    void undoAddressBook();
+    void undoFromHistory();
 
     /**
      * Restores the previously undone address book state from UndoableHistory.
      */
-    void redoAddressBook();
+    void redoFromHistory();
+
+    /**
+     * Returns true if there are previous address book states to restore, and false otherwise.
+     *
+     * @return boolean
+     */
+    boolean canUndoHistory();
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -88,7 +88,7 @@ public interface Model {
     /**
      * Saves the current AddressBook state to the UndoableHistory.
      */
-    void commitToHistory();
+    void commitToHistory(AddressBook addressBook);
 
     /**
      * Restores the previous address book state from UndoableHistory.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -84,4 +84,19 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Saves the current AddressBook state to the UndoableHistory.
+     */
+    void commitAddressBook();
+
+    /**
+     * Restores the previous address book state from UndoableHistory.
+     */
+    void undoAddressBook();
+
+    /**
+     * Restores the previously undone address book state from UndoableHistory.
+     */
+    void redoAddressBook();
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -156,8 +156,8 @@ public class ModelManager implements Model {
      * Saves the current AddressBook state to the UndoableHistory.
      */
     @Override
-    public void commitToHistory() {
-        undoableHistory.commit();
+    public void commitToHistory(AddressBook addressBook) {
+        undoableHistory.commit(addressBook);
     }
 
     /**

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -156,24 +156,34 @@ public class ModelManager implements Model {
      * Saves the current AddressBook state to the UndoableHistory.
      */
     @Override
-    public void commitAddressBook() {
+    public void commitToHistory() {
         undoableHistory.commit();
-    };
+    }
 
     /**
      * Restores the previous address book state from UndoableHistory.
      */
     @Override
-    public void undoAddressBook() {
+    public void undoFromHistory() {
         undoableHistory.undo();
-    };
+    }
 
     /**
      * Restores the previously undone address book state from UndoableHistory.
      */
     @Override
-    public void redoAddressBook() {
+    public void redoFromHistory() {
         undoableHistory.redo();
-    };
+    }
+
+    /**
+     * Returns true if there are previous address book states to restore, and false otherwise.
+     *
+     * @return boolean
+     */
+    @Override
+    public boolean canUndoHistory() {
+        return undoableHistory.canUndo();
+    }
 
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,6 +11,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+
 import seedu.address.model.person.Person;
 
 /**
@@ -82,8 +83,7 @@ public class ModelManager implements Model {
 
     @Override
     public void setAddressBook(ReadOnlyAddressBook readOnlyAddressBook) {
-        // Make a deep-copy of the current state of AddressBook
-        AddressBook addressBook = new AddressBook(undoableHistory.getCurrentState());
+        AddressBook addressBook = undoableHistory.getCurrentState();
 
         // Clear the AddressBook
         addressBook.resetData(readOnlyAddressBook);
@@ -94,6 +94,7 @@ public class ModelManager implements Model {
 
     @Override
     public ReadOnlyAddressBook getAddressBook() {
+
         return undoableHistory.getCurrentState();
     }
 
@@ -105,8 +106,7 @@ public class ModelManager implements Model {
 
     @Override
     public void deletePerson(Person target) {
-        // Make a deep-copy of the current state of AddressBook
-        AddressBook addressBook = new AddressBook(undoableHistory.getCurrentState());
+        AddressBook addressBook = undoableHistory.getCurrentState();
 
         // Delete the person
         addressBook.removePerson(target);
@@ -117,8 +117,8 @@ public class ModelManager implements Model {
 
     @Override
     public void addPerson(Person person) {
-        // Make a deep-copy of the current state of AddressBook
-        AddressBook addressBook = new AddressBook(undoableHistory.getCurrentState());
+
+        AddressBook addressBook = undoableHistory.getCurrentState();
 
         // Add the person
         addressBook.addPerson(person);
@@ -132,8 +132,7 @@ public class ModelManager implements Model {
     public void setPerson(Person target, Person editedPerson) {
         requireAllNonNull(target, editedPerson);
 
-        // Make a deep-copy of the current state of AddressBook
-        AddressBook addressBook = new AddressBook(undoableHistory.getCurrentState());
+        AddressBook addressBook = undoableHistory.getCurrentState();
 
         // Override the target person with the edited Person
         addressBook.setPerson(target, editedPerson);
@@ -212,6 +211,14 @@ public class ModelManager implements Model {
     @Override
     public boolean canUndoHistory() {
         return undoableHistory.canUndo();
+    }
+
+    /**
+     * Clears all future address book states in UndoableHistory beyond the current state.
+     */
+    @Override
+    public void clearFutureHistory() {
+        undoableHistory.clearFutureHistory();
     }
 
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -81,8 +81,15 @@ public class ModelManager implements Model {
     //=========== AddressBook ================================================================================
 
     @Override
-    public void setAddressBook(ReadOnlyAddressBook addressBook) {
-        this.undoableHistory.getCurrentState().resetData(addressBook);
+    public void setAddressBook(ReadOnlyAddressBook readOnlyAddressBook) {
+        // Make a deep-copy of the current state of AddressBook
+        AddressBook addressBook = new AddressBook(undoableHistory.getCurrentState());
+
+        // Clear the AddressBook
+        addressBook.resetData(readOnlyAddressBook);
+
+        // Save the modified AddressBook state to the UndoableHistory
+        commitToHistory(addressBook);
     }
 
     @Override
@@ -98,20 +105,41 @@ public class ModelManager implements Model {
 
     @Override
     public void deletePerson(Person target) {
-        undoableHistory.getCurrentState().removePerson(target);
+        // Make a deep-copy of the current state of AddressBook
+        AddressBook addressBook = new AddressBook(undoableHistory.getCurrentState());
+
+        // Delete the person
+        addressBook.removePerson(target);
+
+        // Save the modified AddressBook state to the UndoableHistory
+        commitToHistory(addressBook);
     }
 
     @Override
     public void addPerson(Person person) {
-        undoableHistory.getCurrentState().addPerson(person);
+        // Make a deep-copy of the current state of AddressBook
+        AddressBook addressBook = new AddressBook(undoableHistory.getCurrentState());
+
+        // Add the person
+        addressBook.addPerson(person);
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
+        // Save the modified AddressBook state to the UndoableHistory
+        commitToHistory(addressBook);
     }
 
     @Override
     public void setPerson(Person target, Person editedPerson) {
         requireAllNonNull(target, editedPerson);
 
-        undoableHistory.getCurrentState().setPerson(target, editedPerson);
+        // Make a deep-copy of the current state of AddressBook
+        AddressBook addressBook = new AddressBook(undoableHistory.getCurrentState());
+
+        // Override the target person with the edited Person
+        addressBook.setPerson(target, editedPerson);
+
+        // Save the modified AddressBook state to the UndoableHistory
+        commitToHistory(addressBook);
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -154,8 +154,8 @@ public class ModelManager implements Model {
 
     @Override
     public void updateFilteredPersonList(Predicate<Person> predicate) {
-            requireNonNull(predicate);
-            filteredPersons.setPredicate(predicate);
+        requireNonNull(predicate);
+        filteredPersons.setPredicate(predicate);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/UndoableHistory.java
+++ b/src/main/java/seedu/address/model/UndoableHistory.java
@@ -21,12 +21,27 @@ public class UndoableHistory {
 
     }
 
-    void redo() {
-
+    /**
+     * Restores the previous address book state from UndoableHistory.
+     */
+    void undo() {
+        currentStateIndexPointer--;
     }
 
-    void undo() {
+    /**
+     * Restores the previously undone address book state from UndoableHistory.
+     */
+    void redo() {
+        currentStateIndexPointer++;
+    }
 
+    /**
+     * Returns true if there are previous address book states to restore, and false otherwise.
+     *
+     * @return boolean
+     */
+    boolean canUndo() {
+        return currentStateIndexPointer <= 0;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/UndoableHistory.java
+++ b/src/main/java/seedu/address/model/UndoableHistory.java
@@ -1,0 +1,59 @@
+package seedu.address.model;
+
+import java.util.ArrayList;
+
+public class UndoableHistory {
+
+    private ArrayList<AddressBook> addressBookStateList;
+    private int currentStateIndexPointer;
+
+    UndoableHistory(AddressBook addressBook) {
+        addressBookStateList = new ArrayList<>();
+        addressBookStateList.add(addressBook);
+        currentStateIndexPointer = 0;
+    }
+
+    AddressBook getCurrentState() {
+        return addressBookStateList.get(currentStateIndexPointer);
+    }
+
+    void commit() {
+
+    }
+
+    void redo() {
+
+    }
+
+    void undo() {
+
+    }
+
+    @Override
+    public String toString() {
+        return addressBookStateList.size() + " states in history";
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) { // short circuit if same object
+            return true;
+        } else {
+            if (!(other instanceof UndoableHistory)) {
+                return false;
+            }
+            UndoableHistory otherHistory = ((UndoableHistory) other);
+            if (currentStateIndexPointer != otherHistory.currentStateIndexPointer
+                    || addressBookStateList.size() != otherHistory.addressBookStateList.size()) {
+                return false;
+            }
+            for (int i = 0; i < addressBookStateList.size(); i++) {
+                if (!addressBookStateList.get(i).equals(otherHistory.addressBookStateList.get(i))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/model/UndoableHistory.java
+++ b/src/main/java/seedu/address/model/UndoableHistory.java
@@ -1,28 +1,64 @@
 package seedu.address.model;
 
+import seedu.address.commons.core.LogsCenter;
+
 import java.util.ArrayList;
+import java.util.logging.Logger;
 
 public class UndoableHistory {
 
+    /** The addressBook that the GUI is in sync with.
+     * This mainAddressBook is updated every time an
+     * undo or redo occurs. It is important that ModelManager
+     * works only with the mainAddressBook object and not
+     * duplicates due to its synchronisation with the GUI.
+     */
+    private AddressBook mainAddressBook;
+
+    private final Logger logger = LogsCenter.getLogger(getClass());
+
+    /**
+     * Deep-copies of mainAddressBook are stored to this list
+     * every time a state-changing command is executed.
+     * This allows mainAddressBook to retrieve its data
+     * from any of these past or future states when an
+     * undo or redo command is called.
+     */
     private ArrayList<AddressBook> addressBookStateList;
     private int currentStateIndexPointer;
 
     UndoableHistory(AddressBook addressBook) {
+        mainAddressBook = addressBook;
         addressBookStateList = new ArrayList<>();
-        addressBookStateList.add(addressBook);
+        // Store a deep-copy of the mainAddressBook to the list
+        addressBookStateList.add(new AddressBook(mainAddressBook));
         currentStateIndexPointer = 0;
     }
 
+    /**
+     * Returns the current state of the AddressBook.
+     *
+     * @return AddressBook mainAddressBook.
+     */
     AddressBook getCurrentState() {
-        return addressBookStateList.get(currentStateIndexPointer);
+        return mainAddressBook;
     }
 
     /**
      * Saves the current AddressBook state to the UndoableHistory.
      */
     void commit(AddressBook addressBook) {
-        addressBookStateList.add(addressBook);
+        // Store a deep-copy of the mainAddressBook to the list
+        AddressBook deepCopy = new AddressBook(addressBook);
+        assert currentStateIndexPointer >= addressBookStateList.size() - 1 :
+                "Pointer always points to end of list during commit; All future states must have been discarded.";
+        addressBookStateList.add(deepCopy);
         currentStateIndexPointer++;
+
+        // -------Logging---------------------------------------------------------------
+        logger.info("State List: ");
+        addressBookStateList.get(currentStateIndexPointer).getPersonList()
+                .forEach(p -> logger.info(p.name.fullName));
     }
 
     /**
@@ -30,6 +66,13 @@ public class UndoableHistory {
      */
     void undo() {
         currentStateIndexPointer--;
+        // Retrieve data from duplicate of its past state
+        mainAddressBook.resetData(addressBookStateList.get(currentStateIndexPointer));
+
+        // -------Logging---------------------------------------------------------------
+        logger.info("State List: ");
+        addressBookStateList.get(currentStateIndexPointer).getPersonList()
+                .forEach(p -> logger.info(p.name.fullName));
     }
 
     /**
@@ -46,6 +89,14 @@ public class UndoableHistory {
      */
     boolean canUndo() {
         return currentStateIndexPointer > 0;
+    }
+
+    /**
+     * Clears all future address book states in addressBookStateList beyond the index given by currentStateIndexPointer
+     */
+    void clearFutureHistory() {
+        addressBookStateList =
+                new ArrayList<>(addressBookStateList.subList(0, currentStateIndexPointer + 1));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/UndoableHistory.java
+++ b/src/main/java/seedu/address/model/UndoableHistory.java
@@ -17,8 +17,12 @@ public class UndoableHistory {
         return addressBookStateList.get(currentStateIndexPointer);
     }
 
-    void commit() {
-
+    /**
+     * Saves the current AddressBook state to the UndoableHistory.
+     */
+    void commit(AddressBook addressBook) {
+        addressBookStateList.add(addressBook);
+        currentStateIndexPointer++;
     }
 
     /**

--- a/src/main/java/seedu/address/model/UndoableHistory.java
+++ b/src/main/java/seedu/address/model/UndoableHistory.java
@@ -3,8 +3,19 @@ package seedu.address.model;
 import seedu.address.commons.core.LogsCenter;
 
 import java.util.ArrayList;
+
 import java.util.logging.Logger;
 
+/**
+ * UndoableHistory contains all AddressBook states
+ * at different points of time in its addressBookStateList
+ * as well as a currentStateIndex that stores the index of the
+ * current AddressBook state in the list.
+ * It also contains a mainAddressBook that represents the current AddressBook
+ * state. Duplicates of this mainAddressBook are stored in the addressBookStateList.
+ * Whenever an undo or redo command is executed, mainAddressBook restores itself to a
+ * past/future state by copying the data in its duplicate over to itself.
+ */
 public class UndoableHistory {
 
     /** The addressBook that the GUI is in sync with.
@@ -50,8 +61,8 @@ public class UndoableHistory {
     void commit(AddressBook addressBook) {
         // Store a deep-copy of the mainAddressBook to the list
         AddressBook deepCopy = new AddressBook(addressBook);
-        assert currentStateIndex >= addressBookStateList.size() - 1 :
-                "Pointer always points to end of list during commit; All future states must have been discarded.";
+        assert currentStateIndex >= addressBookStateList.size() - 1
+                : "Pointer always points to end of list during commit; All future states must have been discarded.";
         addressBookStateList.add(deepCopy);
         currentStateIndex++;
 

--- a/src/main/java/seedu/address/model/UndoableHistory.java
+++ b/src/main/java/seedu/address/model/UndoableHistory.java
@@ -45,7 +45,7 @@ public class UndoableHistory {
      * @return boolean
      */
     boolean canUndo() {
-        return currentStateIndexPointer <= 0;
+        return currentStateIndexPointer > 0;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/UndoableHistory.java
+++ b/src/main/java/seedu/address/model/UndoableHistory.java
@@ -25,14 +25,14 @@ public class UndoableHistory {
      * undo or redo command is called.
      */
     private ArrayList<AddressBook> addressBookStateList;
-    private int currentStateIndexPointer;
+    private int currentStateIndex;
 
     UndoableHistory(AddressBook addressBook) {
         mainAddressBook = addressBook;
         addressBookStateList = new ArrayList<>();
         // Store a deep-copy of the mainAddressBook to the list
         addressBookStateList.add(new AddressBook(mainAddressBook));
-        currentStateIndexPointer = 0;
+        currentStateIndex = 0;
     }
 
     /**
@@ -50,14 +50,14 @@ public class UndoableHistory {
     void commit(AddressBook addressBook) {
         // Store a deep-copy of the mainAddressBook to the list
         AddressBook deepCopy = new AddressBook(addressBook);
-        assert currentStateIndexPointer >= addressBookStateList.size() - 1 :
+        assert currentStateIndex >= addressBookStateList.size() - 1 :
                 "Pointer always points to end of list during commit; All future states must have been discarded.";
         addressBookStateList.add(deepCopy);
-        currentStateIndexPointer++;
+        currentStateIndex++;
 
         // -------Logging---------------------------------------------------------------
         logger.info("State List: ");
-        addressBookStateList.get(currentStateIndexPointer).getPersonList()
+        addressBookStateList.get(currentStateIndex).getPersonList()
                 .forEach(p -> logger.info(p.name.fullName));
     }
 
@@ -65,13 +65,13 @@ public class UndoableHistory {
      * Restores the previous address book state from UndoableHistory.
      */
     void undo() {
-        currentStateIndexPointer--;
+        currentStateIndex--;
         // Retrieve data from duplicate of its past state
-        mainAddressBook.resetData(addressBookStateList.get(currentStateIndexPointer));
+        mainAddressBook.resetData(addressBookStateList.get(currentStateIndex));
 
         // -------Logging---------------------------------------------------------------
         logger.info("State List: ");
-        addressBookStateList.get(currentStateIndexPointer).getPersonList()
+        addressBookStateList.get(currentStateIndex).getPersonList()
                 .forEach(p -> logger.info(p.name.fullName));
     }
 
@@ -79,7 +79,7 @@ public class UndoableHistory {
      * Restores the previously undone address book state from UndoableHistory.
      */
     void redo() {
-        currentStateIndexPointer++;
+        currentStateIndex++;
     }
 
     /**
@@ -88,7 +88,7 @@ public class UndoableHistory {
      * @return boolean
      */
     boolean canUndo() {
-        return currentStateIndexPointer > 0;
+        return currentStateIndex > 0;
     }
 
     /**
@@ -96,7 +96,7 @@ public class UndoableHistory {
      */
     void clearFutureHistory() {
         addressBookStateList =
-                new ArrayList<>(addressBookStateList.subList(0, currentStateIndexPointer + 1));
+                new ArrayList<>(addressBookStateList.subList(0, currentStateIndex + 1));
     }
 
     @Override
@@ -113,7 +113,7 @@ public class UndoableHistory {
                 return false;
             }
             UndoableHistory otherHistory = ((UndoableHistory) other);
-            if (currentStateIndexPointer != otherHistory.currentStateIndexPointer
+            if (currentStateIndex != otherHistory.currentStateIndex
                     || addressBookStateList.size() != otherHistory.addressBookStateList.size()) {
                 return false;
             }

--- a/src/main/java/seedu/address/model/person/Address.java
+++ b/src/main/java/seedu/address/model/person/Address.java
@@ -31,6 +31,15 @@ public class Address {
     }
 
     /**
+     * Returns a deep-copy of an Address.
+     *
+     * @param oldAddress the Address to deep-copy.
+     */
+    public Address(Address oldAddress) {
+        value = oldAddress.value;
+    }
+
+    /**
      * Returns true if a given string is a valid email.
      */
     public static boolean isValidAddress(String test) {

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -41,6 +41,15 @@ public class Email {
     }
 
     /**
+     * Returns a deep-copy of an Email.
+     *
+     * @param oldEmail the Email to deep-copy.
+     */
+    public Email(Email oldEmail) {
+        value = oldEmail.value;
+    }
+
+    /**
      * Returns if a given string is a valid email.
      */
     public static boolean isValidEmail(String test) {

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -32,6 +32,15 @@ public class Name {
     }
 
     /**
+     * Returns a deep-copy of a Name.
+     *
+     * @param oldName the Name to deep-copy.
+     */
+    public Name(Name oldName) {
+        fullName = oldName.fullName;
+    }
+
+    /**
      * Returns true if a given string is a valid name.
      */
     public static boolean isValidName(String test) {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -36,6 +36,19 @@ public class Person {
         this.tags.addAll(tags);
     }
 
+    /**
+     * Returns a deep-copy of a Person.
+     *
+     * @param oldPerson the Person to deep-copy.
+     */
+    public Person(Person oldPerson) {
+        this.name = new Name(oldPerson.name);
+        this.phone = new Phone(oldPerson.phone);
+        this.email = new Email(oldPerson.email);
+        this.address = new Address(oldPerson.address);
+        oldPerson.tags.forEach(tag -> tags.add(new Tag(tag)));
+    }
+
     public Name getName() {
         return name;
     }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -16,7 +16,7 @@ import seedu.address.model.tag.Tag;
 public class Person {
 
     // Identity fields
-    private final Name name;
+    public final Name name; // public to debug
     private final Phone phone;
     private final Email email;
 

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -27,6 +27,15 @@ public class Phone {
     }
 
     /**
+     * Returns a deep-copy of a Phone.
+     *
+     * @param oldPhone the Phone to deep-copy.
+     */
+    public Phone(Phone oldPhone) {
+        value = oldPhone.value;
+    }
+
+    /**
      * Returns true if a given string is a valid phone number.
      */
     public static boolean isValidPhone(String test) {

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -29,6 +29,22 @@ public class UniquePersonList implements Iterable<Person> {
             FXCollections.unmodifiableObservableList(internalList);
 
     /**
+     * Returns a deep-copy of a UniquePersonList.
+     *
+     * @param oldUniquePersonList the UniquePersonList to deep-copy.
+     */
+    public UniquePersonList(UniquePersonList oldUniquePersonList) {
+        for (Person person : oldUniquePersonList.internalList) {
+            // Deep-copy a Person by calling its copy constructor
+            this.internalList.add(new Person(person));
+        }
+    }
+
+    public UniquePersonList() {
+
+    }
+
+    /**
      * Returns true if the list contains an equivalent person as the given argument.
      */
     public boolean contains(Person toCheck) {

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -26,6 +26,15 @@ public class Tag {
     }
 
     /**
+     * Returns a deep-copy of a Tag.
+     *
+     * @param oldTag the Tag to deep-copy.
+     */
+    public Tag(Tag oldTag) {
+        tagName = oldTag.tagName;
+    }
+
+    /**
      * Returns true if a given string is a valid tag name.
      */
     public static boolean isValidTagName(String test) {


### PR DESCRIPTION
I implemented undo command for AB3. (So it uses all the classes like `Persons` in the original AB3, did this because I wanted to get something up first; tweaking it to work for Tasks and Events is not too difficult)

New classes added:
`UndoableHistory` (Stores the list of `AddressBook` states)

The more significant modifications to existing classes: (Don't really have anything too different)

`Model` class now contains an `UndoableHistory` object and no longer an `AddressBook` object. (Because `UndoableHistory` contains all states of `AddressBook` already)

Added Deep-cloning copy constructors for `AddressBook`, `UniquePersonsList`, `Person`, and all classes whose objects are stored in `Person` as variables

Also updated the developer guide highlighting my implementation of the undo command.